### PR TITLE
Do not need to make hterm pull dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-es2015": "^6.3.13",
-    "gulp": "^3.9.1",
+    "gulp": "^4.0.2",
     "gulp-babel": "^6.1.1",
     "gulp-concat": "^2.6.1",
     "gulp-load-plugins": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -17,14 +17,5 @@
   },
   "homepage": "https://github.com/CiscoM31/hterm-es5#readme",
   "dependencies": {},
-  "devDependencies": {
-    "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-    "babel-plugin-transform-object-assign": "^6.22.0",
-    "babel-preset-es2015": "^6.3.13",
-    "gulp": "^4.0.2",
-    "gulp-babel": "^6.1.1",
-    "gulp-concat": "^2.6.1",
-    "gulp-load-plugins": "^1.5.0",
-    "gulp-uglify": "^1.2.0"
-  }
+  "devDependencies": {},  
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "url": "https://github.com/CiscoM31/hterm-es5/issues"
   },
   "homepage": "https://github.com/CiscoM31/hterm-es5#readme",
+  "dependencies": {},
   "devDependencies": {
     "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
     "babel-plugin-transform-object-assign": "^6.22.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/CiscoM31/hterm-es5/issues"
   },
   "homepage": "https://github.com/CiscoM31/hterm-es5#readme",
-  "dependencies": {
+  "devDependencies": {
     "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-es2015": "^6.3.13",

--- a/package.json
+++ b/package.json
@@ -17,5 +17,5 @@
   },
   "homepage": "https://github.com/CiscoM31/hterm-es5#readme",
   "dependencies": {},
-  "devDependencies": {},  
+  "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hterm-es5",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "hterm built and bundled for IE11",
   "main": "dist/hterm.min.js",
   "scripts": {


### PR DESCRIPTION
Some of the dependencies had vulnerabilities flagged by npm install. We don't need npm install to retrieve those as we are using the precompiled dist version of min.js  